### PR TITLE
WIP: query field controller

### DIFF
--- a/spec/API/QueryFieldServiceSpec.php
+++ b/spec/API/QueryFieldServiceSpec.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace spec\BD\EzPlatformQueryFieldType\API;
+
+use BD\EzPlatformQueryFieldType\API\QueryFieldService;
+use BD\EzPlatformQueryFieldType\FieldType\Query;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Query as ApiQuery;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\Core\QueryType\QueryType;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+use eZ\Publish\Core\Repository\Values;
+use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class QueryFieldServiceSpec extends ObjectBehavior
+{
+    const CONTENT_TYPE_ID = 1;
+    const QUERY_TYPE_IDENTIFIER = 'query_type_identifier';
+    const FIELD_DEFINITION_IDENTIFIER = 'test';
+
+    private $searchResult;
+    private $searchHits;
+
+    function let(
+        SearchService $searchService,
+        ContentTypeService $contentTypeService,
+        QueryTypeRegistry $queryTypeRegistry,
+        QueryType $queryType
+    ) {
+        $this->searchHits = [];
+        $this->searchResult = new SearchResult(['searchHits' => $this->searchHits]);
+
+        $parameters = json_encode([
+            'param1' => 'value1',
+            'param2' => 'value2',
+        ]);
+
+        $contentType = new Values\ContentType\ContentType([
+            'fieldDefinitions' => [
+                new Values\ContentType\FieldDefinition([
+                    'identifier' => self::FIELD_DEFINITION_IDENTIFIER,
+                    'fieldTypeIdentifier' => 'query',
+                    'fieldSettings' => [
+                        'ReturnedType' => 'folder',
+                        'QueryType' => self::QUERY_TYPE_IDENTIFIER,
+                        'Parameters' => $parameters,
+                    ]
+                ]),
+            ],
+        ]);
+
+        $contentTypeService->loadContentType(self::CONTENT_TYPE_ID)->willReturn($contentType);
+        $queryTypeRegistry->getQueryType(self::QUERY_TYPE_IDENTIFIER)->willReturn($queryType);
+        $queryType->getQuery(Argument::any())->willReturn(new ApiQuery());
+        // @todo this should fail. It does not.
+        $searchService->findContent(Argument::any())->willReturn($this->searchResult);
+        $this->beConstructedWith($searchService, $contentTypeService, $queryTypeRegistry);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(QueryFieldService::class);
+    }
+
+    function it_loads_data_from_a_query_field_for_a_given_content_item()
+    {
+        $this->loadFieldData($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe($this->searchHits);
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Repository\Values\Content\Content
+     */
+    private function getContent(): Values\Content\Content
+    {
+        return new Values\Content\Content([
+            'versionInfo' => new Values\Content\VersionInfo([
+                'contentInfo' => new ContentInfo(['contentTypeId' => self::CONTENT_TYPE_ID]),
+            ])
+        ]);
+    }
+}

--- a/spec/GraphQL/QueryFieldResolverSpec.php
+++ b/spec/GraphQL/QueryFieldResolverSpec.php
@@ -2,58 +2,19 @@
 
 namespace spec\BD\EzPlatformQueryFieldType\GraphQL;
 
-use BD\EzPlatformQueryFieldType\FieldType\Query;
+use BD\EzPlatformQueryFieldType\API\QueryFieldService;
 use BD\EzPlatformQueryFieldType\GraphQL\QueryFieldResolver;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\API\Repository\Values\Content\Query as ApiQuery;
-use eZ\Publish\Core\QueryType\QueryType;
-use eZ\Publish\Core\QueryType\QueryTypeRegistry;
-use eZ\Publish\Core\Repository\Values;
-use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader;
-use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentTypeLoader;
+use eZ\Publish\Core\Repository\Values\Content\Content;
 use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class QueryFieldResolverSpec extends ObjectBehavior
 {
-    const CONTENT_TYPE_ID = 1;
-    const QUERY_TYPE_IDENTIFIER = 'query_type_identifier';
     const FIELD_DEFINITION_IDENTIFIER = 'test';
-    const RESULTS = [];
 
-    private $contentType;
-
-    function let(
-        ContentLoader $contentLoader,
-        ContentTypeLoader $contentTypeLoader,
-        QueryTypeRegistry $queryTypeRegistry,
-        QueryType $queryType
-    ) {
-        $parameters = json_encode([
-            'param1' => 'value1',
-            'param2' => 'value2',
-        ]);
-
-        $contentType = new Values\ContentType\ContentType([
-            'fieldDefinitions' => [
-                new Values\ContentType\FieldDefinition([
-                    'identifier' => 'test',
-                    'fieldTypeIdentifier' => 'query',
-                    'fieldSettings' => [
-                        'ReturnedType' => 'folder',
-                        'QueryType' => self::QUERY_TYPE_IDENTIFIER,
-                        'Parameters' => $parameters,
-                    ]
-                ]),
-            ],
-        ]);
-
-        $contentTypeLoader->load(self::CONTENT_TYPE_ID)->willReturn($contentType);
-        $queryTypeRegistry->getQueryType(self::QUERY_TYPE_IDENTIFIER)->willReturn($queryType);
-        $queryType->getQuery(Argument::any())->willReturn(new ApiQuery());
-        $contentLoader->find(Argument::any())->willReturn(self::RESULTS);
-        $this->beConstructedWith($contentLoader, $contentTypeLoader, $queryTypeRegistry);
+    function let(QueryFieldService $queryFieldService)
+    {
+        $this->beConstructedWith($queryFieldService);
     }
 
     function it_is_initializable()
@@ -61,31 +22,11 @@ class QueryFieldResolverSpec extends ObjectBehavior
         $this->shouldHaveType(QueryFieldResolver::class);
     }
 
-    function it_resolves_the_value_using_the_configured_query()
+    function it_resolves_a_query_field(QueryFieldService $queryFieldService)
     {
-        $this->resolveQueryField($this->getField(), $this->getContent())->shouldBe(self::RESULTS);
-    }
-
-    /**
-     * @return \EzSystems\EzPlatformGraphQL\GraphQL\Value\Field
-     */
-    private function getField(): Field
-    {
-        return new Field([
-            'fieldDefIdentifier' => self::FIELD_DEFINITION_IDENTIFIER,
-            'value' => new Query\Value(),
-        ]);
-    }
-
-    /**
-     * @return \eZ\Publish\Core\Repository\Values\Content\Content
-     */
-    private function getContent(): Values\Content\Content
-    {
-        return new Values\Content\Content([
-            'versionInfo' => new Values\Content\VersionInfo([
-                'contentInfo' => new ContentInfo(['contentTypeId' => self::CONTENT_TYPE_ID]),
-            ])
-        ]);
+        $content = new Content();
+        $field = new Field(['fieldDefIdentifier' => self::FIELD_DEFINITION_IDENTIFIER, 'value' => new \stdClass()]);
+        $queryFieldService->loadFieldData($content, self::FIELD_DEFINITION_IDENTIFIER)->willReturn([]);
+        $this->resolveQueryField($field, $content)->shouldReturn([]);
     }
 }

--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace BD\EzPlatformQueryFieldType\API;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * Executes a query and returns the results.
+ */
+class QueryFieldService
+{
+    /**
+     * @var \eZ\Publish\Core\QueryType\QueryTypeRegistry
+     */
+    private $queryTypeRegistry;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(
+        SearchService $searchService,
+        ContentTypeService $contentTypeService,
+        QueryTypeRegistry $queryTypeRegistry
+    ) {
+        $this->searchService = $searchService;
+        $this->contentTypeService = $contentTypeService;
+        $this->queryTypeRegistry = $queryTypeRegistry;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function loadFieldData(Content $content, string $fieldDefinitionIdentifier): array
+    {
+        $fieldDefinition = $this->getFieldDefinition($content->contentInfo, $fieldDefinitionIdentifier);
+        $queryType = $this->queryTypeRegistry->getQueryType($fieldDefinition->fieldSettings['QueryType']);
+        $parameters = $this->resolveParameters($fieldDefinition->fieldSettings['Parameters'], $content);
+
+        return array_map(
+            function(SearchHit $searchHit) {
+                return $searchHit->valueObject;
+            },
+            $this->searchService->findContent($queryType->getQuery($parameters))->searchHits
+        );
+    }
+
+    public function getFieldDefinition(ContentInfo $contentInfo, string $fieldDefinitionIdentifier): FieldDefinition
+    {
+        return $queryFieldDefinition =
+            $this
+                ->contentTypeService->loadContentType($contentInfo->contentTypeId)
+                ->getFieldDefinition($fieldDefinitionIdentifier);
+
+    }
+
+    /**
+     * @param string $parameters parameters in JSON format
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return array
+     */
+    private function resolveParameters(string $parameters, Content $content): array
+    {
+        $parameters = json_decode($parameters, true);
+        foreach ($parameters as $key => $parameter) {
+            $parameters[$key] = $this->applyContentToParameter($content, $parameter);
+        }
+
+        return $parameters;
+    }
+
+    private function applyContentToParameter(Content $content, string $parameter)
+    {
+        if (substr($parameter, 0, 2) !== '@=') {
+            return $parameter;
+        }
+
+        return (new ExpressionLanguage())->evaluate(
+            substr($parameter, 2),
+            [
+                'content' => $content,
+                'contentInfo' => $content->contentInfo,
+            ]
+        );
+    }
+}

--- a/src/Controller/QueryFieldController.php
+++ b/src/Controller/QueryFieldController.php
@@ -1,0 +1,33 @@
+<?php
+namespace BD\EzPlatformQueryFieldType\Controller;
+
+use BD\EzPlatformQueryFieldType\API\QueryFieldService;
+use BD\EzPlatformQueryFieldType\GraphQL\QueryFieldResolver;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field as GraphQLField;
+
+class QueryFieldController
+{
+    /**
+     * @var \BD\EzPlatformQueryFieldType\API\QueryFieldService
+     */
+    private $queryFieldService;
+
+    public function __construct(QueryFieldService $queryFieldService)
+    {
+        $this->queryFieldService = $queryFieldService;
+    }
+
+    public function renderQueryFieldAction(ContentView $view, $queryFieldDefinitionIdentifier)
+    {
+        $view->addParameters([
+            'children_view_type' => 'line',
+            'query_results' => $this->queryFieldService->loadFieldData(
+                $view->getContent(),
+                $queryFieldDefinitionIdentifier
+            )
+        ]);
+
+        return $view;
+    }
+}

--- a/src/Controller/QueryFieldRestController.php
+++ b/src/Controller/QueryFieldRestController.php
@@ -1,0 +1,79 @@
+<?php
+namespace BD\EzPlatformQueryFieldType\Controller;
+
+use BD\EzPlatformQueryFieldType\API\QueryFieldService;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\REST\Server\Values\ContentList;
+use eZ\Publish\Core\REST\Server\Values\RestContent;
+
+class QueryFieldRestController
+{
+    /**
+     * @var \BD\EzPlatformQueryFieldType\API\QueryFieldService
+     */
+    private $queryFieldService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\LocationService
+     */
+    private $locationService;
+
+    public function __construct(
+        QueryFieldService $queryFieldService,
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        LocationService $locationService
+    )
+    {
+        $this->queryFieldService = $queryFieldService;
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->locationService = $locationService;
+    }
+
+    public function getResults($contentId, $versionNumber, $fieldDefinitionIdentifier): ContentList
+    {
+        $content = $this->contentService->loadContent($contentId, null, $versionNumber);
+
+        return new ContentList(
+            array_map(
+                function(Content $content) {
+                    return new RestContent(
+                        $content->contentInfo,
+                        $this->locationService->loadLocation($content->contentInfo->mainLocationId),
+                        $content,
+                        $this->getContentType($content->contentInfo),
+                        $this->contentService->loadRelations($content->getVersionInfo())
+                    );
+                },
+                $this->queryFieldService->loadFieldData($content, $fieldDefinitionIdentifier)
+            ),
+        );
+    }
+
+    private function getContentType(ContentInfo $contentInfo): ContentType
+    {
+        static $contentTypes = [];
+
+        if (!isset($contentTypes[$contentInfo->contentTypeId])) {
+            $contentTypes[$contentInfo->contentTypeId] = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
+        }
+
+        return $contentTypes[$contentInfo->contentTypeId];
+    }
+}

--- a/src/FieldType/Query/Type.php
+++ b/src/FieldType/Query/Type.php
@@ -90,7 +90,7 @@ class Type extends FieldType
      */
     public function isEmptyValue(SPIValue $value)
     {
-        return $value->text === null || trim($value->text) === '';
+        return false;
     }
 
     protected function createValueFromInput($inputValue)

--- a/src/GraphQL/QueryFieldResolver.php
+++ b/src/GraphQL/QueryFieldResolver.php
@@ -1,72 +1,23 @@
 <?php
 namespace BD\EzPlatformQueryFieldType\GraphQL;
 
+use BD\EzPlatformQueryFieldType\API\QueryFieldService;
 use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\Core\QueryType\QueryTypeRegistry;
-use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader;
-use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentTypeLoader;
 use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class QueryFieldResolver
 {
     /**
-     * @var QueryTypeRegistry
+     * @var \BD\EzPlatformQueryFieldType\API\QueryFieldService
      */
-    private $queryTypeRegistry;
+    private $queryFieldService;
 
-    /**
-     * @var \EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader
-     */
-    private $contentLoader;
-
-    /**
-     * @var \EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentTypeLoader
-     */
-    private $contentTypeLoader;
-
-    public function __construct(
-        ContentLoader $contentLoader,
-        ContentTypeLoader $contentTypeLoader,
-        QueryTypeRegistry $queryTypeRegistry
-    ) {
-        $this->contentLoader = $contentLoader;
-        $this->contentTypeLoader = $contentTypeLoader;
-        $this->queryTypeRegistry = $queryTypeRegistry;
+    public function __construct(QueryFieldService $queryFieldService) {
+        $this->queryFieldService = $queryFieldService;
     }
 
     public function resolveQueryField(Field $field, Content $content)
     {
-        $queryFieldDefinition =
-            $this
-                ->contentTypeLoader->load($content->contentInfo->contentTypeId)
-                ->getFieldDefinition($field->fieldDefIdentifier);
-
-        $queryType = $this->queryTypeRegistry->getQueryType($queryFieldDefinition->fieldSettings['QueryType']);
-
-        $parameters = $this->resolveParameters(
-            json_decode($queryFieldDefinition->fieldSettings['Parameters'], true),
-            $content
-        );
-
-        return $this->contentLoader->find($queryType->getQuery($parameters));
-    }
-
-    private function resolveParameters(array $parameters, Content $content)
-    {
-        foreach ($parameters as $key => $parameter) {
-            if (substr($parameter, 0, 2) === '@=') {
-                $language = new ExpressionLanguage();
-                $parameters[$key] = $language->evaluate(
-                    substr($parameter, 2),
-                    [
-                        'content' => $content,
-                        'contentInfo' => $content->contentInfo,
-                    ]
-                );
-            }
-        }
-
-        return $parameters;
+        return $this->queryFieldService->loadFieldData($content, $field->fieldDefIdentifier);
     }
 }

--- a/src/Symfony/DependencyInjection/BDEzPlatformQueryFieldTypeExtension.php
+++ b/src/Symfony/DependencyInjection/BDEzPlatformQueryFieldTypeExtension.php
@@ -1,6 +1,7 @@
 <?php
 namespace BD\EzPlatformQueryFieldType\Symfony\DependencyInjection;
 
+use BD\EzPlatformQueryFieldType\Controller\QueryFieldController;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -22,6 +23,9 @@ class BDEzPlatformQueryFieldTypeExtension extends Extension implements PrependEx
         $loader->load('indexable_fieldtypes.yml');
         $loader->load('field_value_converters.yml');
         $loader->load('graphql.yml');
+        $loader->load('services.yml');
+
+        $this->setContentViewConfig($container);
     }
 
     public function prepend(ContainerBuilder $container)
@@ -37,5 +41,21 @@ class BDEzPlatformQueryFieldTypeExtension extends Extension implements PrependEx
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('ezpublish', $config);
         $container->addResource(new FileResource($configFile));
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    protected function setContentViewConfig(ContainerBuilder $container): void
+    {
+        $contentViewDefaults = $container->getParameter('ezsettings.default.content_view_defaults');
+        $contentViewDefaults['query_field'] = [
+            'default' => [
+                'controller' => QueryFieldController::class . ':renderQueryFieldAction',
+                'template' => "BDEzPlatformQueryFieldTypeBundle::query_field_view.html.twig",
+                'match' => [],
+            ]
+        ];
+        $container->setParameter('ezsettings.default.content_view_defaults', $contentViewDefaults);
     }
 }

--- a/src/Symfony/Resources/config/field_templates.yml
+++ b/src/Symfony/Resources/config/field_templates.yml
@@ -1,11 +1,8 @@
 system:
     default:
         fielddefinition_settings_templates:
-            -
-                template: "BDEzPlatformQueryFieldTypeBundle::fielddefinition_settings.html.twig"
+            - { template: "BDEzPlatformQueryFieldTypeBundle::fielddefinition_settings.html.twig" }
         fielddefinition_edit_templates:
-            -
-                template: "BDEzPlatformQueryFieldTypeBundle::field_types.html.twig"
+            - { template: "BDEzPlatformQueryFieldTypeBundle::field_types.html.twig" }
         field_templates:
-            -
-                template: "BDEzPlatformQueryFieldTypeBundle::content_fields.html.twig"
+            - { template: "BDEzPlatformQueryFieldTypeBundle::fieldtype_ui.html.twig" }

--- a/src/Symfony/Resources/config/routing/rest.yml
+++ b/src/Symfony/Resources/config/routing/rest.yml
@@ -1,0 +1,9 @@
+ezpublish_rest_query_field_results:
+    path: /api/ezp/v2/content/objects/{contentId}/versions/{versionNumber}/fields/{fieldDefinitionIdentifier}/query/results
+    defaults:
+        _controller: BD\EzPlatformQueryFieldType\Controller\QueryFieldRestController:getResults
+    methods: [GET]
+    requirements:
+        contentId: \d+
+        fieldId: \d+
+        versionNumber: \d+

--- a/src/Symfony/Resources/config/services.yml
+++ b/src/Symfony/Resources/config/services.yml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+        public: true
+
+    BD\EzPlatformQueryFieldType\Controller\QueryFieldController: ~
+
+    BD\EzPlatformQueryFieldType\API\QueryFieldService: ~

--- a/src/Symfony/Resources/config/services.yml
+++ b/src/Symfony/Resources/config/services.yml
@@ -6,4 +6,6 @@ services:
 
     BD\EzPlatformQueryFieldType\Controller\QueryFieldController: ~
 
+    BD\EzPlatformQueryFieldType\Controller\QueryFieldRestController: ~
+
     BD\EzPlatformQueryFieldType\API\QueryFieldService: ~

--- a/src/Symfony/Resources/views/fielddefinition_settings.html.twig
+++ b/src/Symfony/Resources/views/fielddefinition_settings.html.twig
@@ -1,6 +1,6 @@
 {% extends '@EzPublishCore/fielddefinition_settings.html.twig' %}
 
-{% block bdquery_settings %}
+{% block query_settings %}
     <li class="ez-fielddefinition-setting query-type">
         <div class="ez-fielddefinition-setting-name">{{ 'query_field_type.field_definition.query_type.label'|trans|desc("Query type:")}}</div>
         <div class="ez-fielddefinition-setting-value">

--- a/src/Symfony/Resources/views/fieldtype_ui.html.twig
+++ b/src/Symfony/Resources/views/fieldtype_ui.html.twig
@@ -1,8 +1,15 @@
 {% extends '@EzPublishCore/content_fields.html.twig' %}
 
-{% block bdquery_field %}
+{% block query_field %}
 {% spaceless %}
-    {% set field_value = field.value.text %}
-    {{ block( 'simple_inline_field' ) }}
+    {{ render(controller(
+        "ez_content:viewAction",
+        {
+            "contentId": contentInfo.id,
+            "queryFieldDefinitionIdentifier": field.fieldDefIdentifier,
+            "viewType": "query_field"
+        }
+    )) }}
+
 {% endspaceless %}
 {% endblock %}

--- a/src/Symfony/Resources/views/query_field_view.html.twig
+++ b/src/Symfony/Resources/views/query_field_view.html.twig
@@ -1,0 +1,6 @@
+{% for result in query_results %}
+    {{ render(controller("ez_content:viewAction", {
+        "contentId": result.id,
+        "viewType": children_view_type
+    })) }}
+{% endfor %}


### PR DESCRIPTION
> Implements #6

### `ez_render_field` support using the view controller
Adds fields value rendering using a view controller. It runs the query using the `query_field` view. Results are displayed using the `line` view.

![Example in the admin](https://user-images.githubusercontent.com/235928/47850499-b6d53a00-ddd5-11e8-8030-98a5b0f57147.png)

### REST support
Adds a custom REST resource that returns the query results:
```
GET /api/ezp/v2/content/objects/{contentId}/versions/{versionNo}/fields/{identifier}/query/results
```

Returns an `application/vnd.ez.api.ContentList`.

### TODO
- [x] load default view settings
- [x] Extract query resolution, and use it in resolver + controller
- [x] ~~Pagination support, with offset and limit query parameters in REST Public API~~ (will be fixed in a future change)